### PR TITLE
fix: added new line between parameters and constructor after invoking 'Generate constructor' action

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -979,7 +979,7 @@ class DataClassGenerator {
                 constr += 'const ';
         }
 
-        constr += clazz.name + startBracket + '\n';
+        constr += '\n' + clazz.name + startBracket + '\n';
 
         // Add 'Key key,' for widgets in constructor.
         if (clazz.isWidget) {


### PR DESCRIPTION
Added new line between parameters and constructor after invoking 'Generate constructor' action.

before:
![old](https://github.com/ricardoemerson/dart-data-class-tools/assets/42470814/45f09567-541a-4778-be22-e78982af945f)

now:
![new](https://github.com/ricardoemerson/dart-data-class-tools/assets/42470814/232589bd-cc9a-4d4e-896c-d92e06c7b450)
