### PR TITLE
ValueGetter code simplification

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1083,7 +1083,7 @@ class DataClassGenerator {
 
         for (let p of clazz.properties) {
             if (usesValueGetter && p.isNullable) {
-                method += `    ${ clazz.hasNamedConstructor ? `${ p.name }: ` : '' }${ p.name } != null ? ${ p.name }() : this.${ p.name },\n`;
+                method += `    ${ clazz.hasNamedConstructor ? `${ p.name }: ` : '' }${ p.name }?.call() ?? this.${ p.name },\n`;
             } else {
                 method += `    ${ clazz.hasNamedConstructor ? `${ p.name }: ` : '' }${ p.name } ?? this.${ p.name },\n`;
             }


### PR DESCRIPTION
Generated code for ValueGetter can be simplified. 

From 

```
x != null ? x() : this.x
```
to 

```dart
x?.call() ?? this.x
```