### PR TITLE
fix: prefer use ISO8601 then parse due to milliseconds digits

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1115,7 +1115,7 @@ class DataClassGenerator {
 
             switch (prop.type) {
                 case 'DateTime':
-                    return `${name}${nullSafe}.millisecondsSinceEpoch${endFlag}`;
+                    return `${name}${nullSafe}.toIso8601String(){endFlag}`;
                 case 'Color':
                     return `${name}${nullSafe}.value${endFlag}`;
                 case 'IconData':
@@ -1167,7 +1167,7 @@ class DataClassGenerator {
 
             switch (prop.type) {
                 case 'DateTime':
-                    return `DateTime.fromMillisecondsSinceEpoch(${value})`;
+                    return `DateTime.parse(${value})`;
                 case 'Color':
                     return `Color(${value})`;
                 case 'IconData':


### PR DESCRIPTION
DateTime.fromMillisecondsSinceEpoch constructor can cause not equal between two DateTime(s) since it will not fill microseconds value.

For example,
```dart
void main() {
  final now = DateTime.now();
  final foo = Foo(now);
  final newFoo = Foo.fromMap(foo.toMap());

  print(foo == newFoo); // false
  print(foo.createdAt == newFoo.createdAt); // false
  print(foo.createdAt == now); // true
  print(newFoo.createdAt == now); // false
  print(foo.createdAt); // yyyy-mm-dd HH:mm:ss.xxxxxx (contains microseconds)
  print(newFoo.createdAt); // yyyy-mm-dd HH:mm:ss.xxx (missing microseconds)
}

class Foo {
  final DateTime createdAt;

  Foo(this.createdAt);

  factory Foo.fromMap(Map<String, dynamic> map) {
    return Foo(DateTime.fromMillisecondsSinceEpoch(map['createdAt']));
  }

  Map<String, dynamic> toMap() {
    return {
      'createdAt': createdAt.millisecondsSinceEpoch,
    };
  }

  @override
  bool operator ==(Object other) {
    if (identical(this, other)) return true;

    return other is Foo && other.createdAt == createdAt;
  }

  @override
  int get hashCode {
    return createdAt.hashCode;
  }
}
```